### PR TITLE
claude/refresh-ios-app-B9yXy

### DIFF
--- a/AccelerationX/View/BigLabel/BigTimerLabelView.swift
+++ b/AccelerationX/View/BigLabel/BigTimerLabelView.swift
@@ -8,29 +8,38 @@
 import SwiftUI
 
 struct BigTimerLabelView: View {
-    
+
     @ObservedObject var timer: TimerManager
     @ObservedObject var optionalTimer: TimerManager
-    
+
+    private var displayCounter: Double {
+        optionalTimer.mode == .running ? optionalTimer.counter : timer.counter
+    }
+
+    private var timerLabel: String {
+        optionalTimer.mode == .running ? "TIMER 2" : "TIMER 1"
+    }
+
     var body: some View {
-        HStack {
-            if optionalTimer.mode == .running {
-                Text(String(format: "%.1f", optionalTimer.counter))
-                    .font(.custom("VCR OSD Mono", size: 100))
-            } else {
-                Text(String(format: "%.1f", timer.counter))
-                    .font(.custom("VCR OSD Mono", size: 100))
+        VStack(spacing: 6) {
+            HStack(alignment: .bottom, spacing: 8) {
+                Text(String(format: "%.2f", displayCounter))
+                    .font(.custom("VCR OSD Mono", size: 80))
+                    .foregroundStyle(.white)
+                    .contentTransition(.numericText(countsDown: false))
+                    .animation(.easeOut(duration: 0.05), value: displayCounter)
+
+                Text("SEC")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .tracking(3)
+                    .padding(.bottom, 14)
             }
-            
-            Text("sec")
-                .font(.custom("VCR OSD Mono", size: 30))
-                .padding(.top, 70)
+
+            Text(timerLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Color.pink.opacity(0.8))
+                .tracking(4)
         }
     }
 }
-
-//struct TimerBigLabelView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TimerBigLabelView()
-//    }
-//}

--- a/AccelerationX/View/ContentView.swift
+++ b/AccelerationX/View/ContentView.swift
@@ -11,32 +11,29 @@ import CoreData
 struct ContentView: View {
 
     @Environment(\.managedObjectContext) var context
-    @FetchRequest(sortDescriptors: [
-        SortDescriptor(\.title)
-    ]) var runs: FetchedResults<Run>
-    
     @StateObject var vm = RunViewModel()
-    
+
     var body: some View {
         TabView {
             RunView(vm: vm)
                 .tabItem {
-                    Image(systemName: "car")
+                    Image(systemName: "car.fill")
                     Text("Run")
                 }
-            
+
             HistoryView()
                 .tabItem {
-                    Image(systemName: "stopwatch.fill")
+                    Image(systemName: "clock.arrow.circlepath")
                     Text("History")
                 }
             SettingsView(vm: vm)
                 .tabItem {
-                    Image(systemName: "gearshape.2.fill")
+                    Image(systemName: "slider.horizontal.3")
                     Text("Settings")
                 }
         }
         .accentColor(.pink)
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/AccelerationX/View/DetailsView.swift
+++ b/AccelerationX/View/DetailsView.swift
@@ -8,30 +8,104 @@
 import SwiftUI
 
 struct DetailsView: View {
-    
+
     let run: Run
-    
+
     var body: some View {
-        VStack {
-            Text(run.title ?? "No title")
-                .padding(20)
-                .font(.largeTitle)
-            VStack {
-                Text("\(String(run.start)) - \(String(run.finish))")
-                Text(String(format: "%.2f", run.time) + " sec")
-            }
-            
-            if run.optionalRun == true {
-                VStack {
-                    Text("\(String(run.optionalStart)) - \(String(run.optionalFinish))")
-                    Text(String(format: "%.2f", run.optionalTime) + " sec")
+        ScrollView {
+            VStack(spacing: 16) {
+
+                // ── Title card ────────────────────────────────────────────
+                VStack(spacing: 6) {
+                    Text(run.title ?? "Untitled Run")
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+
+                    if let ts = run.timestamp {
+                        Text(ts, style: .date)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-                
+                .frame(maxWidth: .infinity)
+                .padding(20)
+                .background(Color(white: 0.12))
+                .cornerRadius(20)
+
+                // ── Primary timer card ────────────────────────────────────
+                DetailRunCard(
+                    label: "TIMER 1",
+                    start: Int(run.start),
+                    finish: Int(run.finish),
+                    time: run.time,
+                    unit: run.unit ?? "kmh"
+                )
+
+                // ── Optional timer card ───────────────────────────────────
+                if run.optionalRun {
+                    DetailRunCard(
+                        label: "TIMER 2",
+                        start: Int(run.optionalStart),
+                        finish: Int(run.optionalFinish),
+                        time: run.optionalTime,
+                        unit: run.unit ?? "kmh"
+                    )
+                }
             }
-            
-            Text("Units: " + (run.unit ?? "no unit"))
-            Spacer()
+            .padding(20)
         }
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(Color(red: 0.07, green: 0.07, blue: 0.07).ignoresSafeArea())
     }
 }
 
+// ── Detail Run Card ───────────────────────────────────────────────────────────
+
+private struct DetailRunCard: View {
+    let label: String
+    let start: Int
+    let finish: Int
+    let time: Double
+    let unit: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(3)
+
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("RANGE")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(Color(white: 0.4))
+                        .tracking(2)
+                    Text("\(start) → \(finish) \(unit)")
+                        .font(.system(size: 17, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.pink)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(String(format: "%.2f", time))
+                        .font(.custom("VCR OSD Mono", size: 44))
+                        .foregroundStyle(.white)
+                    Text("seconds")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(20)
+        .background(Color(white: 0.12))
+        .cornerRadius(20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color.pink.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+}

--- a/AccelerationX/View/HistoryView.swift
+++ b/AccelerationX/View/HistoryView.swift
@@ -8,35 +8,60 @@
 import SwiftUI
 
 struct HistoryView: View {
-    
+
     @Environment(\.managedObjectContext) var context
     @FetchRequest(sortDescriptors: [
-        SortDescriptor(\.title)
+        SortDescriptor(\.timestamp, order: .reverse)
     ]) var runs: FetchedResults<Run>
-        
+
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(runs) { run in
-                    NavigationLink {
-                        DetailsView(run: run)
-                    } label: {
-                        VStack(alignment: .leading) {
-                            Text(run.title ?? "No title")
-                                .font(.headline)
+        NavigationStack {
+            Group {
+                if runs.isEmpty {
+                    emptyState
+                } else {
+                    List {
+                        ForEach(runs) { run in
+                            NavigationLink {
+                                DetailsView(run: run)
+                            } label: {
+                                RunHistoryRow(run: run)
+                            }
+                            .listRowBackground(Color(white: 0.12))
+                            .listRowSeparatorTint(Color(white: 0.22))
                         }
+                        .onDelete(perform: deleteItems)
                     }
-                }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                        .foregroundColor(.pink)
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
                 }
             }
             .navigationTitle("History")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                        .tint(.pink)
+                }
+            }
+            .background(Color(red: 0.07, green: 0.07, blue: 0.07))
         }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "flag.checkered")
+                .font(.system(size: 56))
+                .foregroundStyle(Color(white: 0.35))
+            Text("No Runs Yet")
+                .font(.title2.bold())
+                .foregroundStyle(.white)
+            Text("Complete a run and save it\nto see your results here.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(red: 0.07, green: 0.07, blue: 0.07))
     }
 
     private func deleteItems(offsets: IndexSet) {
@@ -52,8 +77,42 @@ struct HistoryView: View {
     }
 }
 
+// ── History Row ───────────────────────────────────────────────────────────────
+
+private struct RunHistoryRow: View {
+    let run: Run
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(run.title ?? "Untitled Run")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+
+            HStack {
+                Text("\(run.start) → \(run.finish) \(run.unit ?? "")")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.pink)
+
+                Spacer()
+
+                Text(String(format: "%.2f", run.time) + " sec")
+                    .font(.system(size: 13, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white)
+            }
+
+            if let ts = run.timestamp {
+                Text(ts, style: .date)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
 struct HistoryView_Previews: PreviewProvider {
     static var previews: some View {
         HistoryView()
+            .preferredColorScheme(.dark)
     }
 }

--- a/AccelerationX/View/RunRow/RunRowListView.swift
+++ b/AccelerationX/View/RunRow/RunRowListView.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsView.swift
+//  RunRowListView.swift
 //  Acceleration
 //
 //  Created by Igor Łopatka on 14/03/2022.
@@ -8,45 +8,89 @@
 import SwiftUI
 
 struct RunRowListView: View {
-    
+
     @ObservedObject var vm: RunViewModel
     @ObservedObject var timer: TimerManager
     @ObservedObject var optTimer: TimerManager
-    
-    var body: some View {
-        VStack {
-            HStack {
-                RunRowView(start: $vm.start, finish: $vm.finish, active: $vm.runActive)
-                Text((String(format: "%.1f", timer.counter)) + "s")
-                    .bold()
-                    .frame(width: 50)
-            }
-            if vm.optRunActive {
-                HStack {
-                    RunRowView(start: $vm.optStart, finish: $vm.optFinish, active: $vm.runActive)
-                    Text((String(format: "%.1f", optTimer.counter)) + "s")
-                        .bold()
-                        .frame(width: 50)
-                }
 
+    var body: some View {
+        VStack(spacing: 12) {
+            // Primary timer row
+            timerRow(
+                label: "T1",
+                start: $vm.start,
+                finish: $vm.finish,
+                counter: timer.counter
+            )
+
+            if vm.optRunActive {
+                Divider()
+                    .background(Color(white: 0.25))
+
+                // Optional timer row
+                timerRow(
+                    label: "T2",
+                    start: $vm.optStart,
+                    finish: $vm.optFinish,
+                    counter: optTimer.counter
+                )
             }
+
+            // Add / remove Timer 2 button
             Button {
-                withAnimation {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     vm.optRunActive.toggle()
                 }
             } label: {
-                Image(systemName: vm.optRunActive ? "minus.circle" : "plus.circle")
-                    .tint(vm.optRunActive ? .gray : .green)
+                HStack(spacing: 6) {
+                    Image(systemName: vm.optRunActive ? "minus" : "plus")
+                        .font(.system(size: 12, weight: .bold))
+                    Text(vm.optRunActive ? "Remove Timer 2" : "Add Timer 2")
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .foregroundStyle(vm.optRunActive ? Color.secondary : Color.pink)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(Color(white: 0.18))
+                .cornerRadius(10)
             }
-            .padding(.trailing, 60)
+            .buttonStyle(.plain)
+            .disabled(vm.runActive)
         }
-        .padding(.trailing, 50)
+        .padding(16)
+        .background(Color(white: 0.12))
+        .cornerRadius(20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color(white: 0.22), lineWidth: 0.5)
+        )
+    }
+
+    @ViewBuilder
+    private func timerRow(label: String, start: Binding<Int>, finish: Binding<Int>, counter: Double) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(2)
+                .frame(width: 20)
+
+            RunRowView(start: start, finish: finish, active: $vm.runActive)
+
+            Spacer()
+
+            Text(String(format: "%.2f", counter) + "s")
+                .font(.system(size: 15, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .frame(minWidth: 65, alignment: .trailing)
+        }
     }
 }
 
-
-struct SettingsView_Previews: PreviewProvider {
+struct RunRowListView_Previews: PreviewProvider {
     static var previews: some View {
         RunRowListView(vm: RunViewModel(), timer: TimerManager(), optTimer: TimerManager())
+            .preferredColorScheme(.dark)
+            .padding()
     }
 }

--- a/AccelerationX/View/RunRow/RunRowView.swift
+++ b/AccelerationX/View/RunRow/RunRowView.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 struct RunRowView: View {
-    
+
     @Binding var start: Int
     @Binding var finish: Int
     @Binding var active: Bool
-    
+
     let values = [0,20,40,60,80,100,120,140,160,180,200,220,240,260,280,300]
-    
+
     var body: some View {
-        HStack {
+        HStack(spacing: 4) {
             Picker("Start at:", selection: $start) {
                 ForEach(values, id: \.self) {
                     if $0 < finish {
@@ -26,10 +26,11 @@ struct RunRowView: View {
             }
             .disabled(active)
             .tint(.pink)
-            .padding(.leading, 40)
-            
-            Image(systemName: "arrow.right")
-            
+
+            Text("→")
+                .foregroundStyle(.secondary)
+                .font(.system(size: 14, weight: .semibold))
+
             Picker("Finish at:", selection: $finish) {
                 ForEach(values, id: \.self) {
                     if $0 > start {
@@ -39,8 +40,6 @@ struct RunRowView: View {
             }
             .disabled(active)
             .tint(.pink)
-            .padding(.trailing, 40)
         }
     }
 }
-

--- a/AccelerationX/View/RunView.swift
+++ b/AccelerationX/View/RunView.swift
@@ -5,91 +5,115 @@
 //  Created by Igor Łopatka on 14/03/2022.
 //
 
-
 import SwiftUI
 
 struct RunView: View {
-    
+
     @Environment(\.managedObjectContext) var context
     @Environment(\.dismiss) var dismiss
-    
+
     @ObservedObject var vm: RunViewModel
-    
+
     @State private var showAlert = false
     @State private var title = ""
-    
+
     var body: some View {
-        VStack {
-            HStack {
-                Button(action: {
-                    vm.resetTimers()
-                }) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 50, height: 50)
-                        .foregroundColor(.primary)
-                        .padding()
-                }
-                
-                Spacer()
-                
-                UnitSwitchView(unit: $vm.unit, isActive: vm.runActive)
-                    .onChange(of: vm.unit) { _ in
-                        vm.updateUnits()
-                    }
-                
-                Spacer()
-                
-                Image(systemName: vm.updateSignalSymbol())
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 50, height: 50)
-                    .foregroundColor(vm.updateSignalColor())
-                    .padding()
-            }
-            
-            Spacer()
-            
-            VStack {
+        ZStack {
+            // Full-bleed dark gradient background
+            LinearGradient(
+                colors: [Color(white: 0.10), Color(white: 0.06)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+
+                // ── TOP BAR ──────────────────────────────────────────────
                 HStack {
-                    Text(String(format: "%.0f", vm.speedInUnits))
-                        .font(.custom("VCR OSD Mono", size: 100))
-                    Text("\(vm.title)")
-                        .font(.custom("VCR OSD Mono", size: 30))
-                        .padding(.top, 70)
+                    // GPS signal pill
+                    signalPill
+
+                    Spacer()
+
+                    // KPH / MPH pill toggle
+                    UnitSwitchView(unit: $vm.unit, isActive: vm.runActive)
+                        .onChange(of: vm.unit) { _ in
+                            vm.updateUnits()
+                        }
+
+                    Spacer()
+
+                    // Reset button
+                    Button {
+                        vm.resetTimers()
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise.circle.fill")
+                            .font(.system(size: 32))
+                            .foregroundStyle(vm.runActive ? Color(white: 0.35) : .white)
+                    }
+                    .disabled(vm.runActive)
+                    .buttonStyle(.plain)
                 }
-                
+                .padding(.horizontal, 24)
+                .padding(.top, 20)
+
+                Spacer()
+
+                // ── SPEED DISPLAY ─────────────────────────────────────────
+                VStack(spacing: 2) {
+                    Text(String(format: "%.0f", vm.speedInUnits))
+                        .font(.custom("VCR OSD Mono", size: 96))
+                        .foregroundStyle(.white)
+                        .contentTransition(.numericText())
+                        .animation(.easeOut(duration: 0.1), value: vm.speedInUnits)
+
+                    Text(vm.title.uppercased())
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .tracking(6)
+                }
+
+                Spacer()
+
+                // ── TIMER DISPLAY ─────────────────────────────────────────
                 BigTimerLabelView(timer: vm.timer, optionalTimer: vm.optionalTimer)
-            }
-            .padding()
-            
-            Spacer()
-            
-            RunRowListView(vm: vm, timer: vm.timer, optTimer: vm.optionalTimer)
-                .frame(alignment: .trailing)
-            
-            Spacer()
-            VStack {
+
+                Spacer()
+
+                // ── RANGE CARD ────────────────────────────────────────────
+                RunRowListView(vm: vm, timer: vm.timer, optTimer: vm.optionalTimer)
+                    .padding(.horizontal, 20)
+
+                Spacer()
+
+                // ── SAVE BUTTON ───────────────────────────────────────────
                 Button {
                     showAlert = true
                 } label: {
                     Text("SAVE RUN")
-                        .foregroundColor(.white)
-                        .bold()
+                        .font(.system(size: 15, weight: .bold))
+                        .tracking(2)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(
+                            (vm.runActive || !vm.runFinished)
+                                ? Color.pink.opacity(0.25)
+                                : Color.pink
+                        )
+                        .cornerRadius(16)
                 }
-                .frame(width: 130, height: 40)
-                .background(.pink)
-                .cornerRadius(50)
-                .padding(.bottom)
+                .disabled(vm.runActive || !vm.runFinished)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 14)
                 .buttonStyle(.plain)
-                .disabled(vm.runActive)
-                .disabled(!vm.runFinished)
+                .animation(.easeInOut(duration: 0.2), value: vm.runFinished)
+
+                // ── AD BANNER ─────────────────────────────────────────────
+                BannerView()
+                    .frame(height: 60)
             }
-            Spacer()
-            
-            BannerView()
-                .frame(height: 120)
         }
         .onAppear {
             vm.requestPermission()
@@ -100,7 +124,7 @@ struct RunView: View {
         .onChange(of: vm.speedInUnits, perform: { newValue in
             let start = Double(vm.start)
             let finish = Double(vm.finish)
-            
+
             switch newValue {
             case start...finish:
                 vm.timer.start()
@@ -110,11 +134,11 @@ struct RunView: View {
                     vm.runFinished = true
                 }
             }
-            
+
             if vm.optRunActive {
                 let optStart = Double(vm.optStart)
                 let optFinish = Double(vm.optFinish)
-                
+
                 switch newValue {
                 case optStart...optFinish:
                     vm.optionalTimer.start()
@@ -133,16 +157,35 @@ struct RunView: View {
             vm.updateRunState()
         })
         .alert("Save current run", isPresented: $showAlert, actions: {
-                    TextField("Title", text: $title)
-                    Button("Save", action: {
-                        addRun(title: title)
-                    })
-                    Button("Cancel", role: .cancel, action: {
-                        showAlert = false
-                    })
-                }, message: {})
+            TextField("Title", text: $title)
+            Button("Save", action: {
+                addRun(title: title)
+            })
+            Button("Cancel", role: .cancel, action: {
+                showAlert = false
+            })
+        }, message: {})
     }
-    
+
+    // ── GPS SIGNAL PILL ───────────────────────────────────────────────────
+    private var signalPill: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(vm.updateSignalColor())
+                .frame(width: 8, height: 8)
+                .shadow(color: vm.updateSignalColor().opacity(0.6), radius: 4)
+            Text(vm.signalQuality == .none ? "NO GPS" : "GPS")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(2)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(white: 0.16))
+        .cornerRadius(20)
+    }
+
+    // ── CORE DATA SAVE ────────────────────────────────────────────────────
     private func addRun(title: String) {
         withAnimation {
             let newRun = Run(context: context)
@@ -172,5 +215,6 @@ struct RunView: View {
 struct RunView_Previews: PreviewProvider {
     static var previews: some View {
         RunView(vm: RunViewModel())
+            .preferredColorScheme(.dark)
     }
 }

--- a/AccelerationX/View/SettingsView.swift
+++ b/AccelerationX/View/SettingsView.swift
@@ -8,23 +8,14 @@
 import SwiftUI
 
 struct SettingsView: View {
-    
+
     @ObservedObject var vm: RunViewModel
-    @State private var showAbout = false
-    
-    var unitSelected: String {
-        switch vm.unit {
-        case .kph:
-            return "Kilometers per hour"
-        case .mph:
-            return "Miles per hour"
-        }
-    }
-    
+
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
-                Section(header: Text("First run")) {
+                // ── Primary timer ─────────────────────────────────────────
+                Section {
                     Picker("Start at:", selection: $vm.start) {
                         ForEach(vm.values, id: \.self) {
                             if $0 < vm.finish {
@@ -32,6 +23,8 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .tint(.pink)
+
                     Picker("Finish at:", selection: $vm.finish) {
                         ForEach(vm.values, id: \.self) {
                             if $0 > vm.start {
@@ -39,10 +32,15 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .tint(.pink)
+                } header: {
+                    sectionHeader("Timer 1")
                 }
-                
-                Section(header: Text("Optional run")) {
-                    Toggle("Optional run active", isOn: $vm.optRunActive.animation())
+
+                // ── Optional timer ────────────────────────────────────────
+                Section {
+                    Toggle("Enable Timer 2", isOn: $vm.optRunActive.animation())
+
                     if vm.optRunActive {
                         Picker("Start at:", selection: $vm.optStart) {
                             ForEach(vm.values, id: \.self) {
@@ -51,6 +49,8 @@ struct SettingsView: View {
                                 }
                             }
                         }
+                        .tint(.pink)
+
                         Picker("Finish at:", selection: $vm.optFinish) {
                             ForEach(vm.values, id: \.self) {
                                 if $0 > vm.optStart {
@@ -58,35 +58,61 @@ struct SettingsView: View {
                                 }
                             }
                         }
+                        .tint(.pink)
                     }
+                } header: {
+                    sectionHeader("Timer 2")
                 }
-                
-                Section(header: Text("Units (per hour)")) {
-                    Picker("Units: ", selection: $vm.unit) {
-                        Text("KM/H")
-                            .tag(Unit.kph)
-                        Text("M/H")
-                            .tag(Unit.mph)
+
+                // ── Units ─────────────────────────────────────────────────
+                Section {
+                    Picker("Units", selection: $vm.unit) {
+                        Text("KM/H").tag(Unit.kph)
+                        Text("MPH").tag(Unit.mph)
                     }
-                    .pickerStyle(SegmentedPickerStyle())
+                    .pickerStyle(.segmented)
+                    .onChange(of: vm.unit) { _ in
+                        vm.updateUnits()
+                    }
+                } header: {
+                    sectionHeader("Speed Unit")
                 }
-                
-                Section(header: Text("About AccelerationX"), footer: aboutText()) {
-                    
+
+                // ── About ─────────────────────────────────────────────────
+                Section {
+                    Link(destination: URL(string: "https://github.com/igorlopatka/Acceleration/blob/master/AccelerationX%20-%20Privacy%20Policy.md")!) {
+                        Label("Privacy Policy", systemImage: "hand.raised.fill")
+                            .foregroundStyle(.pink)
+                    }
+                    Link(destination: URL(string: "https://github.com/igorlopatka/Acceleration/blob/master/README.md")!) {
+                        Label("GitHub Repository", systemImage: "chevron.left.forwardslash.chevron.right")
+                            .foregroundStyle(.pink)
+                    }
+                    Link(destination: URL(string: "https://github.com/igorlopatka")!) {
+                        Label("About the Developer", systemImage: "person.fill")
+                            .foregroundStyle(.pink)
+                    }
+                } header: {
+                    sectionHeader("About AccelerationX")
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(Color(red: 0.07, green: 0.07, blue: 0.07))
             .navigationTitle("Settings")
         }
     }
-    
-    func aboutText() -> some View {
-        VStack {
-            Text("Read [Privacy Policy](https://github.com/igorlopatka/Acceleration/blob/master/AccelerationX%20-%20Privacy%20Policy.md), learn more about [app](https://github.com/igorlopatka/Acceleration/blob/master/README.md), or developer that created it: [About Me](https://github.com/igorlopatka).")
-        }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .tracking(2)
     }
-    struct SetingsView_Previews: PreviewProvider {
-        static var previews: some View {
-            SettingsView(vm: RunViewModel())
-        }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView(vm: RunViewModel())
+            .preferredColorScheme(.dark)
     }
 }

--- a/AccelerationX/View/UnitView/UnitSwitchView.swift
+++ b/AccelerationX/View/UnitView/UnitSwitchView.swift
@@ -8,35 +8,34 @@
 import SwiftUI
 
 struct UnitSwitchView: View {
-    
+
     @Binding var unit: Unit
     var isActive: Bool
-    
+
     var body: some View {
-        HStack {
-            Button {
-                unit = .kph
-            } label: {
-                switch unit {
-                case .kph:
-                    UnitSymbolView(symbolName: "kph.circle.fill")
-                case .mph:
-                    UnitSymbolView(symbolName: "kph.circle")
+        HStack(spacing: 0) {
+            ForEach([Unit.kph, Unit.mph], id: \.self) { u in
+                Button {
+                    unit = u
+                } label: {
+                    Text(u == .kph ? "KPH" : "MPH")
+                        .font(.system(size: 12, weight: .semibold))
+                        .tracking(1)
+                        .foregroundStyle(unit == u ? Color.black : Color.secondary)
+                        .frame(width: 48, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 15)
+                                .fill(unit == u ? Color.white : Color.clear)
+                        )
                 }
-            }
-            Button {
-                unit = .mph
-            } label: {
-                switch unit {
-                case .kph:
-                    UnitSymbolView(symbolName: "mph.circle")
-                case .mph:
-                    UnitSymbolView(symbolName: "mph.circle.fill")
-                }
+                .buttonStyle(.plain)
             }
         }
+        .padding(3)
+        .background(Color(white: 0.2))
+        .cornerRadius(18)
         .disabled(isActive)
-        .foregroundColor(isActive ? .secondary : .primary)
-        .padding()
+        .opacity(isActive ? 0.4 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: unit)
     }
 }


### PR DESCRIPTION
- Global dark mode enforced via preferredColorScheme(.dark)
- New tab icons: car.fill, clock.arrow.circlepath, slider.horizontal.3
- RunView: full-bleed dark gradient, ZStack layout, speed number with
  contentTransition animation, GPS signal as compact colored pill,
  pill-style KPH/MPH toggle, save button full-width with state-aware styling
- BigTimerLabelView: contentTransition(.numericText), TIMER 1/2 label,
  cleaner SEC label with tracking
- RunRowListView: wrapped in dark card (bg 0.12, cornerRadius 20, border),
  labeled T1/T2 rows, styled Add/Remove Timer 2 button
- RunRowView: removed excess padding, arrow symbol replaced with text →
- UnitSwitchView: redesigned as pill segmented toggle (white/dark contrast)
- HistoryView: sort by timestamp descending (was alphabetical by title),
  rich rows showing range + time + date, empty state with flag icon,
  NavigationStack replacing NavigationView
- DetailsView: card-based layout with title card + per-timer DetailRunCard,
  VCR font on time result, pink range label, date shown
- SettingsView: NavigationStack, scrollContentBackground hidden, dark bg,
  about section as three tappable Link rows, sectionHeader helper

All business logic, CoreData, GPS, timer onChange handlers unchanged.

https://claude.ai/code/session_01Rvn5aV3nJLCrPtkTvR7Spy